### PR TITLE
SparkPost attachment fixes

### DIFF
--- a/lib/dm_courier/services/sparkpost.rb
+++ b/lib/dm_courier/services/sparkpost.rb
@@ -91,7 +91,7 @@ module DMCourier
         attachments(inline: false).map do |attachment|
           { name: attachment[:name],
             type: attachment[:type],
-            content: attachment[:content] }
+            data: attachment[:content] }
         end
       end
 
@@ -99,7 +99,7 @@ module DMCourier
         attachments(inline: true).map do |attachment|
           { name: attachment[:name],
             type: attachment[:type],
-            content: attachment[:content] }
+            data: attachment[:content] }
         end
       end
     end

--- a/lib/dm_courier/version.rb
+++ b/lib/dm_courier/version.rb
@@ -1,3 +1,3 @@
 module DMCourier
-  VERSION = "0.1.1".freeze
+  VERSION = "0.1.2".freeze
 end

--- a/spec/dm_courier/services/sparkpost_spec.rb
+++ b/spec/dm_courier/services/sparkpost_spec.rb
@@ -48,7 +48,7 @@ describe DMCourier::Services::Sparkpost do
 
         service = described_class.new(mail, options)
         expect(service.sparkpost_message[:content][:attachments]).to eq(
-          [{ name: "text.txt", type: "text/plain", content: "VGhpcyBpcyBhIHRlc3Q=\n" }]
+          [{ name: "text.txt", type: "text/plain", data: "VGhpcyBpcyBhIHRlc3Q=\n" }]
         )
       end
 
@@ -168,7 +168,7 @@ describe DMCourier::Services::Sparkpost do
         expect(service.sparkpost_message[:content][:inline_images]).to eq(
           [{ name: mail.attachments[0].cid,
              type: "image/jpg",
-             content: "VGhpcyBpcyBhIHRlc3Q=\n" }]
+             data: "VGhpcyBpcyBhIHRlc3Q=\n" }]
         )
       end
 


### PR DESCRIPTION
Changes attachment object for sparkpost service to uses 'data' as key of hash besides 'content'.